### PR TITLE
Revamp blog structure and fix link visibility

### DIFF
--- a/blogs.html
+++ b/blogs.html
@@ -75,223 +75,135 @@
 
             <div id="main" class="s-content__main large-8 column">
                 <article class="entry">
-
                     <header class="entry__header">
-
                         <h2 class="entry__title h1">
-                            <a title="">New York City Trip Day 5 of 5</a>
+                            <a href="blogs/blog-0526-2024.html" title="">Graduated from Brown!!!</a>
                         </h2>
+                        <div class="entry__meta">
+                            <ul>
+                                <li>May 26, 2024</li>
+                                <li>Ruida Zeng</li>
+                            </ul>
+                        </div>
+                    </header>
+                </article> <!-- end entry -->
 
+                <article class="entry">
+                    <header class="entry__header">
+                        <h2 class="entry__title h1">
+                            <a href="blogs/blog-0110-2023.html" title="">New York City Trip Day 5 of 5</a>
+                        </h2>
                         <div class="entry__meta">
                             <ul>
                                 <li>January 10, 2023</li>
                                 <li>Ruida Zeng, Ashton Gurrola, Yifei Zhao</li>
                             </ul>
                         </div>
-
                     </header>
-
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/CobpAmxt3hk"
-                    title="YouTube video player"
-                    frameborder="0"
-                    allowfullscreen></iframe>
-
                 </article> <!-- end entry -->
+
                 <article class="entry">
-
                     <header class="entry__header">
-
                         <h2 class="entry__title h1">
-                            <a title="">New York City Trip Day 4 of 5</a>
+                            <a href="blogs/blog-0109-2023.html" title="">New York City Trip Day 4 of 5</a>
                         </h2>
-
                         <div class="entry__meta">
                             <ul>
                                 <li>January 9, 2023</li>
                                 <li>Ruida Zeng, Ashton Gurrola</li>
                             </ul>
                         </div>
-
                     </header>
-
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/p5CTMF68vco"
-                    title="YouTube video player"
-                    frameborder="0"
-                    allowfullscreen></iframe>
-
                 </article> <!-- end entry -->
+
                 <article class="entry">
-
                     <header class="entry__header">
-
                         <h2 class="entry__title h1">
-                            <a title="">New York City Trip Day 3 of 5</a>
+                            <a href="blogs/blog-0108-2023.html" title="">New York City Trip Day 3 of 5</a>
                         </h2>
-
                         <div class="entry__meta">
                             <ul>
                                 <li>January 8, 2023</li>
                                 <li>Ruida Zeng, Ashton Gurrola</li>
                             </ul>
                         </div>
-
                     </header>
-
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/JITUZWj1ty0"
-                    title="YouTube video player"
-                    frameborder="0"
-                    allowfullscreen></iframe>
-
                 </article> <!-- end entry -->
+
                 <article class="entry">
-
                     <header class="entry__header">
-
                         <h2 class="entry__title h1">
-                            <a title="">New York City Trip Day 2 of 5</a>
+                            <a href="blogs/blog-0107-2023.html" title="">New York City Trip Day 2 of 5</a>
                         </h2>
-
                         <div class="entry__meta">
                             <ul>
                                 <li>January 7, 2023</li>
                                 <li>Ruida Zeng, Ashton Gurrola, Frankie Cao</li>
                             </ul>
                         </div>
-
                     </header>
-
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/0KVLKKLaLEk"
-                    title="YouTube video player"
-                    frameborder="0"
-                    allowfullscreen></iframe>
-
                 </article> <!-- end entry -->
+
                 <article class="entry">
-
                     <header class="entry__header">
-
                         <h2 class="entry__title h1">
-                            <a title="">New York City Trip Day 1 of 5</a>
+                            <a href="blogs/blog-0106-2023.html" title="">New York City Trip Day 1 of 5</a>
                         </h2>
-
                         <div class="entry__meta">
                             <ul>
                                 <li>January 6, 2023</li>
                                 <li>Ruida Zeng, Ashton Gurrola</li>
                             </ul>
                         </div>
-
                     </header>
-
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/E7YQw8iiIgA"
-                    title="YouTube video player"
-                    frameborder="0"
-                    allowfullscreen></iframe>
-
                 </article> <!-- end entry -->
+
                 <article class="entry">
-
                     <header class="entry__header">
-
                         <h2 class="entry__title h1">
                             <a href="blogs/blog-0710-2022.html" title="">Cantonese Food Review (Part 1)</a>
                         </h2>
-
                         <div class="entry__meta">
                             <ul>
                                 <li>July 10, 2022</li>
                                 <li>Ruida Zeng</li>
                             </ul>
                         </div>
-
                     </header>
-
-                    <div class="entry__content">
-                        <p>
-                          Over the last few months in Guangzhou, China, I have had the opportunity to try
-                          some unique Cantonese food from all over the city. Some of them are well known
-                          dishes internationally, while some are rather exotic cuisine that are only popular
-                          locally. I will be introducing a few of them here in my blog from my personal
-                          tasting experience.
-                        </p>
-                        <p>
-                        <a href="blogs/blog-0710-2022.html">Read Full Article</a>
-                        </p>
-                        <div class="entry__content-media">
-                            <img src="images/food/chicken.jpg"
-                                 srcset="images/food/chicken.jpg 1000w,
-                                         images/food/chicken.jpg 500w"
-                                 sizes="(max-width: 500px) 100vw, 500px" alt="chicken">
-                        </div>
-                    </div>
-
                 </article> <!-- end entry -->
 
                 <article class="entry">
-
                     <header class="entry__header">
-
                         <h2 class="entry__title h1">
-                            <a title="">Graduated from Vandy!!!</a>
+                            <a href="blogs/blog-1215-2021.html" title="">Graduated from Vandy!!!</a>
                         </h2>
-
                         <div class="entry__meta">
                             <ul>
                                 <li>December 15, 2021</li>
                                 <li>Ruida Zeng</li>
                             </ul>
                         </div>
-
                     </header>
-
-                    <div class="entry__content">
-                        <p>
-                        Today I took the last exam of my undergraduate college career. The campus was peaceful
-                        and quiet, as most people had already left for winter break. Although I expected the
-                        end to be more ceremonious than this, I couldn't help but think that the rare tranquility
-                        called for a moment of self-reflection.
-                        </p>
-                        <p>
-                        For me, college was a juxtaposition of accompolishments and failures, of hope and despair,
-                        of dreams and nightmares. Looking back, there were memories that I cherish dearly as well
-                        as things that I deeply regret. At the end of the day, the most important thing about 3.5
-                        years at Vanderbilt is that I grew tremendously as a person, both in terms of my technical
-                        knowledge and my mental maturity. And for that, I am content and forever grateful.
-                        </p>
-                        <div class="entry__content-media">
-                            <img src="images/vandy.jpg"
-                                 srcset="images/vandy.jpg 1000w,
-                                         images/vandy.jpg 500w"
-                                 sizes="(max-width: 500px) 100vw, 500px" alt="vandy">
-                        </div>
-                    </div>
-
                 </article> <!-- end entry -->
 
                 <article class="entry">
-
                     <header class="entry__header">
-
                         <h2 class="entry__title h1">
                             <a title="">First Blog Post Ever!</a>
                         </h2>
-
                         <div class="entry__meta">
                             <ul>
                                 <li>August 6, 2019</li>
                                 <li>Ruida Zeng</li>
                             </ul>
                         </div>
-
                     </header>
-
                     <div class="entry__content">
                         <p>
                         Does this thing even work?
                         </p>
                         <img src="images/squirrel.jpg" alt="squirrel" class="lazyload" style="width:50%">
                     </div>
-
                 </article> <!-- end entry -->
 
                 <!-- page nav -->

--- a/blogs/blog-0106-2023.html
+++ b/blogs/blog-0106-2023.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>New York City Trip Day 1 of 5</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../images/icons/squirrel-icon.png" type="image/icon type">
+    <script src="../js/theme.js"></script>
+    <link rel="stylesheet" href="../css/base.css">
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../css/dark-mode.css">
+    <script src="../js/modernizr.js"></script>
+    <script defer src="../js/fontawesome/all.min.js"></script>
+    <script src="../js/sky.js" defer></script>
+</head>
+
+<body id="top">
+    <canvas class="sky-canvas" aria-hidden="true"></canvas>
+
+    <div id="preloader">
+        <div id="loader" class="dots-fade">
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <header class="s-header">
+        <div class="row">
+            <div class="s-header__content column">
+                <div class="s-header__brand">
+                    <h1 class="s-header__logotext">
+                        <a href="../blogs.html" title="">Ruida's Room</a>
+                    </h1>
+                    <p class="s-header__tagline">Private thoughts, book & movie reviews, and yummy recipes.</p>
+                </div>
+            </div>
+        </div>
+
+        <nav class="s-header__nav-wrap">
+          <div class="row">
+               <ul class="s-header__nav">
+                   <li><a href="../index.html">Home</a></li>
+                   <li><a href="../news.html">News</a></li>
+                   <li><a href="../publications.html">Publications</a></li>
+                   <li><a href="../projects.html">Projects</a></li>
+                   <li class="current"><a href="../blogs.html">Blogs</a></li>
+                   <li><a href="../contact.html">Contact</a></li>
+               </ul>
+           </div>
+       </nav>
+
+        <a class="header-menu-toggle" href="#0"><span>Menu</span></a>
+    </header>
+
+    <div class="s-content">
+        <div class="row">
+            <div id="main" class="s-content__main large-8 column">
+                <article class="entry">
+                    <header class="entry__header">
+                        <h2 class="entry__title h1">
+                            <a href="blog-0106-2023.html" title="New York City Trip Day 1 of 5">New York City Trip Day 1 of 5</a>
+                        </h2>
+                        <div class="entry__meta">
+                            <ul>
+                                <li>January 6, 2023</li>
+                                <li>Ruida Zeng, Ashton Gurrola</li>
+                            </ul>
+                        </div>
+                    </header>
+
+                    <div class="entry__content">
+                        <iframe width="560" height="315" src="https://www.youtube.com/embed/E7YQw8iiIgA"
+                        title="YouTube video player"
+                        frameborder="0"
+                        allowfullscreen></iframe>
+                    </div>
+                </article>
+            </div>
+
+            <div id="sidebar" class="s-content__sidebar large-4 column">
+                <div class="widget widget_tags">
+                    <h3 class="h6">Post Tags</h3>
+                    <div class="tagcloud group">
+                        <a href="#0">Travel</a>
+                        <a href="#0">NYC</a>
+                        <a href="#0">Vlog</a>
+                    </div>
+                </div>
+
+                <div class="widget widget_popular">
+                    <h3 class="h6">Other Posts</h3>
+                    <ul class="link-list">
+                        <li><a href="blog-0110-2023.html">NYC Trip Day 5 of 5</a></li>
+                        <li><a href="blog-0109-2023.html">NYC Trip Day 4 of 5</a></li>
+                        <li><a href="blog-0108-2023.html">NYC Trip Day 3 of 5</a></li>
+                        <li><a href="blog-0107-2023.html">NYC Trip Day 2 of 5</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="s-footer">
+        <div class="row s-footer__bottom">
+            <div class="column">
+                <div class="ss-copyright">
+                    <span>© Ruida Zeng 2025</span>
+                    <span>Design by <a href="https://www.styleshout.com/">StyleShout</a></span>
+                </div>
+            </div>
+        </div>
+        <div class="ss-go-top">
+            <a class="smoothscroll" title="Back to Top" href="#top">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0l8 9h-6v15h-4v-15h-6z"/></svg>
+            </a>
+        </div>
+    </footer>
+
+    <script src="../js/jquery-3.2.1.min.js"></script>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/blogs/blog-0107-2023.html
+++ b/blogs/blog-0107-2023.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>New York City Trip Day 2 of 5</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../images/icons/squirrel-icon.png" type="image/icon type">
+    <script src="../js/theme.js"></script>
+    <link rel="stylesheet" href="../css/base.css">
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../css/dark-mode.css">
+    <script src="../js/modernizr.js"></script>
+    <script defer src="../js/fontawesome/all.min.js"></script>
+    <script src="../js/sky.js" defer></script>
+</head>
+
+<body id="top">
+    <canvas class="sky-canvas" aria-hidden="true"></canvas>
+
+    <div id="preloader">
+        <div id="loader" class="dots-fade">
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <header class="s-header">
+        <div class="row">
+            <div class="s-header__content column">
+                <div class="s-header__brand">
+                    <h1 class="s-header__logotext">
+                        <a href="../blogs.html" title="">Ruida's Room</a>
+                    </h1>
+                    <p class="s-header__tagline">Private thoughts, book & movie reviews, and yummy recipes.</p>
+                </div>
+            </div>
+        </div>
+
+        <nav class="s-header__nav-wrap">
+          <div class="row">
+               <ul class="s-header__nav">
+                   <li><a href="../index.html">Home</a></li>
+                   <li><a href="../news.html">News</a></li>
+                   <li><a href="../publications.html">Publications</a></li>
+                   <li><a href="../projects.html">Projects</a></li>
+                   <li class="current"><a href="../blogs.html">Blogs</a></li>
+                   <li><a href="../contact.html">Contact</a></li>
+               </ul>
+           </div>
+       </nav>
+
+        <a class="header-menu-toggle" href="#0"><span>Menu</span></a>
+    </header>
+
+    <div class="s-content">
+        <div class="row">
+            <div id="main" class="s-content__main large-8 column">
+                <article class="entry">
+                    <header class="entry__header">
+                        <h2 class="entry__title h1">
+                            <a href="blog-0107-2023.html" title="New York City Trip Day 2 of 5">New York City Trip Day 2 of 5</a>
+                        </h2>
+                        <div class="entry__meta">
+                            <ul>
+                                <li>January 7, 2023</li>
+                                <li>Ruida Zeng, Ashton Gurrola, Frankie Cao</li>
+                            </ul>
+                        </div>
+                    </header>
+
+                    <div class="entry__content">
+                        <iframe width="560" height="315" src="https://www.youtube.com/embed/0KVLKKLaLEk"
+                        title="YouTube video player"
+                        frameborder="0"
+                        allowfullscreen></iframe>
+                    </div>
+                </article>
+            </div>
+
+            <div id="sidebar" class="s-content__sidebar large-4 column">
+                <div class="widget widget_tags">
+                    <h3 class="h6">Post Tags</h3>
+                    <div class="tagcloud group">
+                        <a href="#0">Travel</a>
+                        <a href="#0">NYC</a>
+                        <a href="#0">Vlog</a>
+                    </div>
+                </div>
+
+                <div class="widget widget_popular">
+                    <h3 class="h6">Other Posts</h3>
+                    <ul class="link-list">
+                        <li><a href="blog-0110-2023.html">NYC Trip Day 5 of 5</a></li>
+                        <li><a href="blog-0109-2023.html">NYC Trip Day 4 of 5</a></li>
+                        <li><a href="blog-0108-2023.html">NYC Trip Day 3 of 5</a></li>
+                        <li><a href="blog-0106-2023.html">NYC Trip Day 1 of 5</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="s-footer">
+        <div class="row s-footer__bottom">
+            <div class="column">
+                <div class="ss-copyright">
+                    <span>© Ruida Zeng 2025</span>
+                    <span>Design by <a href="https://www.styleshout.com/">StyleShout</a></span>
+                </div>
+            </div>
+        </div>
+        <div class="ss-go-top">
+            <a class="smoothscroll" title="Back to Top" href="#top">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0l8 9h-6v15h-4v-15h-6z"/></svg>
+            </a>
+        </div>
+    </footer>
+
+    <script src="../js/jquery-3.2.1.min.js"></script>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/blogs/blog-0108-2023.html
+++ b/blogs/blog-0108-2023.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>New York City Trip Day 3 of 5</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../images/icons/squirrel-icon.png" type="image/icon type">
+    <script src="../js/theme.js"></script>
+    <link rel="stylesheet" href="../css/base.css">
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../css/dark-mode.css">
+    <script src="../js/modernizr.js"></script>
+    <script defer src="../js/fontawesome/all.min.js"></script>
+    <script src="../js/sky.js" defer></script>
+</head>
+
+<body id="top">
+    <canvas class="sky-canvas" aria-hidden="true"></canvas>
+
+    <div id="preloader">
+        <div id="loader" class="dots-fade">
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <header class="s-header">
+        <div class="row">
+            <div class="s-header__content column">
+                <div class="s-header__brand">
+                    <h1 class="s-header__logotext">
+                        <a href="../blogs.html" title="">Ruida's Room</a>
+                    </h1>
+                    <p class="s-header__tagline">Private thoughts, book & movie reviews, and yummy recipes.</p>
+                </div>
+            </div>
+        </div>
+
+        <nav class="s-header__nav-wrap">
+          <div class="row">
+               <ul class="s-header__nav">
+                   <li><a href="../index.html">Home</a></li>
+                   <li><a href="../news.html">News</a></li>
+                   <li><a href="../publications.html">Publications</a></li>
+                   <li><a href="../projects.html">Projects</a></li>
+                   <li class="current"><a href="../blogs.html">Blogs</a></li>
+                   <li><a href="../contact.html">Contact</a></li>
+               </ul>
+           </div>
+       </nav>
+
+        <a class="header-menu-toggle" href="#0"><span>Menu</span></a>
+    </header>
+
+    <div class="s-content">
+        <div class="row">
+            <div id="main" class="s-content__main large-8 column">
+                <article class="entry">
+                    <header class="entry__header">
+                        <h2 class="entry__title h1">
+                            <a href="blog-0108-2023.html" title="New York City Trip Day 3 of 5">New York City Trip Day 3 of 5</a>
+                        </h2>
+                        <div class="entry__meta">
+                            <ul>
+                                <li>January 8, 2023</li>
+                                <li>Ruida Zeng, Ashton Gurrola</li>
+                            </ul>
+                        </div>
+                    </header>
+
+                    <div class="entry__content">
+                        <iframe width="560" height="315" src="https://www.youtube.com/embed/JITUZWj1ty0"
+                        title="YouTube video player"
+                        frameborder="0"
+                        allowfullscreen></iframe>
+                    </div>
+                </article>
+            </div>
+
+            <div id="sidebar" class="s-content__sidebar large-4 column">
+                <div class="widget widget_tags">
+                    <h3 class="h6">Post Tags</h3>
+                    <div class="tagcloud group">
+                        <a href="#0">Travel</a>
+                        <a href="#0">NYC</a>
+                        <a href="#0">Vlog</a>
+                    </div>
+                </div>
+
+                <div class="widget widget_popular">
+                    <h3 class="h6">Other Posts</h3>
+                    <ul class="link-list">
+                        <li><a href="blog-0110-2023.html">NYC Trip Day 5 of 5</a></li>
+                        <li><a href="blog-0109-2023.html">NYC Trip Day 4 of 5</a></li>
+                        <li><a href="blog-0107-2023.html">NYC Trip Day 2 of 5</a></li>
+                        <li><a href="blog-0106-2023.html">NYC Trip Day 1 of 5</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="s-footer">
+        <div class="row s-footer__bottom">
+            <div class="column">
+                <div class="ss-copyright">
+                    <span>© Ruida Zeng 2025</span>
+                    <span>Design by <a href="https://www.styleshout.com/">StyleShout</a></span>
+                </div>
+            </div>
+        </div>
+        <div class="ss-go-top">
+            <a class="smoothscroll" title="Back to Top" href="#top">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0l8 9h-6v15h-4v-15h-6z"/></svg>
+            </a>
+        </div>
+    </footer>
+
+    <script src="../js/jquery-3.2.1.min.js"></script>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/blogs/blog-0109-2023.html
+++ b/blogs/blog-0109-2023.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>New York City Trip Day 4 of 5</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../images/icons/squirrel-icon.png" type="image/icon type">
+    <script src="../js/theme.js"></script>
+    <link rel="stylesheet" href="../css/base.css">
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../css/dark-mode.css">
+    <script src="../js/modernizr.js"></script>
+    <script defer src="../js/fontawesome/all.min.js"></script>
+    <script src="../js/sky.js" defer></script>
+</head>
+
+<body id="top">
+    <canvas class="sky-canvas" aria-hidden="true"></canvas>
+
+    <div id="preloader">
+        <div id="loader" class="dots-fade">
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <header class="s-header">
+        <div class="row">
+            <div class="s-header__content column">
+                <div class="s-header__brand">
+                    <h1 class="s-header__logotext">
+                        <a href="../blogs.html" title="">Ruida's Room</a>
+                    </h1>
+                    <p class="s-header__tagline">Private thoughts, book & movie reviews, and yummy recipes.</p>
+                </div>
+            </div>
+        </div>
+
+        <nav class="s-header__nav-wrap">
+          <div class="row">
+               <ul class="s-header__nav">
+                   <li><a href="../index.html">Home</a></li>
+                   <li><a href="../news.html">News</a></li>
+                   <li><a href="../publications.html">Publications</a></li>
+                   <li><a href="../projects.html">Projects</a></li>
+                   <li class="current"><a href="../blogs.html">Blogs</a></li>
+                   <li><a href="../contact.html">Contact</a></li>
+               </ul>
+           </div>
+       </nav>
+
+        <a class="header-menu-toggle" href="#0"><span>Menu</span></a>
+    </header>
+
+    <div class="s-content">
+        <div class="row">
+            <div id="main" class="s-content__main large-8 column">
+                <article class="entry">
+                    <header class="entry__header">
+                        <h2 class="entry__title h1">
+                            <a href="blog-0109-2023.html" title="New York City Trip Day 4 of 5">New York City Trip Day 4 of 5</a>
+                        </h2>
+                        <div class="entry__meta">
+                            <ul>
+                                <li>January 9, 2023</li>
+                                <li>Ruida Zeng, Ashton Gurrola</li>
+                            </ul>
+                        </div>
+                    </header>
+
+                    <div class="entry__content">
+                        <iframe width="560" height="315" src="https://www.youtube.com/embed/p5CTMF68vco"
+                        title="YouTube video player"
+                        frameborder="0"
+                        allowfullscreen></iframe>
+                    </div>
+                </article>
+            </div>
+
+            <div id="sidebar" class="s-content__sidebar large-4 column">
+                <div class="widget widget_tags">
+                    <h3 class="h6">Post Tags</h3>
+                    <div class="tagcloud group">
+                        <a href="#0">Travel</a>
+                        <a href="#0">NYC</a>
+                        <a href="#0">Vlog</a>
+                    </div>
+                </div>
+
+                <div class="widget widget_popular">
+                    <h3 class="h6">Other Posts</h3>
+                    <ul class="link-list">
+                        <li><a href="blog-0110-2023.html">NYC Trip Day 5 of 5</a></li>
+                        <li><a href="blog-0108-2023.html">NYC Trip Day 3 of 5</a></li>
+                        <li><a href="blog-0107-2023.html">NYC Trip Day 2 of 5</a></li>
+                        <li><a href="blog-0106-2023.html">NYC Trip Day 1 of 5</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="s-footer">
+        <div class="row s-footer__bottom">
+            <div class="column">
+                <div class="ss-copyright">
+                    <span>© Ruida Zeng 2025</span>
+                    <span>Design by <a href="https://www.styleshout.com/">StyleShout</a></span>
+                </div>
+            </div>
+        </div>
+        <div class="ss-go-top">
+            <a class="smoothscroll" title="Back to Top" href="#top">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0l8 9h-6v15h-4v-15h-6z"/></svg>
+            </a>
+        </div>
+    </footer>
+
+    <script src="../js/jquery-3.2.1.min.js"></script>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/blogs/blog-0110-2023.html
+++ b/blogs/blog-0110-2023.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>New York City Trip Day 5 of 5</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../images/icons/squirrel-icon.png" type="image/icon type">
+    <script src="../js/theme.js"></script>
+    <link rel="stylesheet" href="../css/base.css">
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../css/dark-mode.css">
+    <script src="../js/modernizr.js"></script>
+    <script defer src="../js/fontawesome/all.min.js"></script>
+    <script src="../js/sky.js" defer></script>
+</head>
+
+<body id="top">
+    <canvas class="sky-canvas" aria-hidden="true"></canvas>
+
+    <div id="preloader">
+        <div id="loader" class="dots-fade">
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <header class="s-header">
+        <div class="row">
+            <div class="s-header__content column">
+                <div class="s-header__brand">
+                    <h1 class="s-header__logotext">
+                        <a href="../blogs.html" title="">Ruida's Room</a>
+                    </h1>
+                    <p class="s-header__tagline">Private thoughts, book & movie reviews, and yummy recipes.</p>
+                </div>
+            </div>
+        </div>
+
+        <nav class="s-header__nav-wrap">
+          <div class="row">
+               <ul class="s-header__nav">
+                   <li><a href="../index.html">Home</a></li>
+                   <li><a href="../news.html">News</a></li>
+                   <li><a href="../publications.html">Publications</a></li>
+                   <li><a href="../projects.html">Projects</a></li>
+                   <li class="current"><a href="../blogs.html">Blogs</a></li>
+                   <li><a href="../contact.html">Contact</a></li>
+               </ul>
+           </div>
+       </nav>
+
+        <a class="header-menu-toggle" href="#0"><span>Menu</span></a>
+    </header>
+
+    <div class="s-content">
+        <div class="row">
+            <div id="main" class="s-content__main large-8 column">
+                <article class="entry">
+                    <header class="entry__header">
+                        <h2 class="entry__title h1">
+                            <a href="blog-0110-2023.html" title="New York City Trip Day 5 of 5">New York City Trip Day 5 of 5</a>
+                        </h2>
+                        <div class="entry__meta">
+                            <ul>
+                                <li>January 10, 2023</li>
+                                <li>Ruida Zeng, Ashton Gurrola, Yifei Zhao</li>
+                            </ul>
+                        </div>
+                    </header>
+
+                    <div class="entry__content">
+                        <iframe width="560" height="315" src="https://www.youtube.com/embed/CobpAmxt3hk"
+                        title="YouTube video player"
+                        frameborder="0"
+                        allowfullscreen></iframe>
+                    </div>
+                </article>
+            </div>
+
+            <div id="sidebar" class="s-content__sidebar large-4 column">
+                <div class="widget widget_tags">
+                    <h3 class="h6">Post Tags</h3>
+                    <div class="tagcloud group">
+                        <a href="#0">Travel</a>
+                        <a href="#0">NYC</a>
+                        <a href="#0">Vlog</a>
+                    </div>
+                </div>
+
+                <div class="widget widget_popular">
+                    <h3 class="h6">Other Posts</h3>
+                    <ul class="link-list">
+                        <li><a href="blog-0109-2023.html">NYC Trip Day 4 of 5</a></li>
+                        <li><a href="blog-0108-2023.html">NYC Trip Day 3 of 5</a></li>
+                        <li><a href="blog-0107-2023.html">NYC Trip Day 2 of 5</a></li>
+                        <li><a href="blog-0106-2023.html">NYC Trip Day 1 of 5</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="s-footer">
+        <div class="row s-footer__bottom">
+            <div class="column">
+                <div class="ss-copyright">
+                    <span>© Ruida Zeng 2025</span>
+                    <span>Design by <a href="https://www.styleshout.com/">StyleShout</a></span>
+                </div>
+            </div>
+        </div>
+        <div class="ss-go-top">
+            <a class="smoothscroll" title="Back to Top" href="#top">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0l8 9h-6v15h-4v-15h-6z"/></svg>
+            </a>
+        </div>
+    </footer>
+
+    <script src="../js/jquery-3.2.1.min.js"></script>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/blogs/blog-0526-2024.html
+++ b/blogs/blog-0526-2024.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Graduated from Brown!!!</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../images/icons/squirrel-icon.png" type="image/icon type">
+    <script src="../js/theme.js"></script>
+    <link rel="stylesheet" href="../css/base.css">
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../css/dark-mode.css">
+    <script src="../js/modernizr.js"></script>
+    <script defer src="../js/fontawesome/all.min.js"></script>
+    <script src="../js/sky.js" defer></script>
+</head>
+
+<body id="top">
+    <canvas class="sky-canvas" aria-hidden="true"></canvas>
+
+    <!-- preloader
+    ================================================== -->
+    <div id="preloader">
+        <div id="loader" class="dots-fade">
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <!-- Header
+    ================================================== -->
+    <header class="s-header">
+
+        <div class="row">
+            <div class="s-header__content column">
+                <div class="s-header__brand">
+                    <h1 class="s-header__logotext">
+                        <a href="../blogs.html" title="">Ruida's Room</a>
+                    </h1>
+                    <p class="s-header__tagline">Private thoughts, book & movie reviews, and yummy recipes.</p>
+                </div>
+            </div>
+        </div> <!-- end row -->
+
+        <nav class="s-header__nav-wrap">
+
+          <div class="row">
+
+               <ul class="s-header__nav">
+                   <li><a href="../index.html">Home</a></li>
+                   <li><a href="../news.html">News</a></li>
+                   <li><a href="../publications.html">Publications</a></li>
+                   <li><a href="../projects.html">Projects</a></li>
+                   <li class="current"><a href="../blogs.html">Blogs</a></li>
+                   <li><a href="../contact.html">Contact</a></li>
+               </ul>
+
+           </div>
+
+       </nav>
+
+        <a class="header-menu-toggle" href="#0"><span>Menu</span></a>
+
+    </header>
+
+    <!-- Content
+    ================================================== -->
+    <div class="s-content">
+
+        <div class="row">
+
+            <div id="main" class="s-content__main large-8 column">
+
+                <article class="entry">
+
+                    <header class="entry__header">
+
+                        <h2 class="entry__title h1">
+                            <a href="blog-0526-2024.html" title="Graduated from Brown!!!">Graduated from Brown!!!</a>
+                        </h2>
+
+                        <div class="entry__meta">
+                            <ul>
+                                <li>May 26, 2024</li>
+                                <li>Ruida Zeng</li>
+                            </ul>
+                        </div>
+
+                    </header>
+
+                    <div class="entry__content">
+                        <p>
+                            I officially finished my master's degree at Brown! It feels surreal to be done — these
+                            past two years flew by way faster than I expected. Between the coursework, research, and
+                            everything in between, it was honestly one of the most intense but rewarding chapters of
+                            my life.
+                        </p>
+                        <p>
+                            Providence grew on me more than I thought it would. The late-night walks on Thayer Street,
+                            the coffee shops I practically lived in during finals, and the friends I made along the way —
+                            I'm going to miss all of it. But more than anything, I'm proud of how much I pushed myself
+                            and how much I learned, not just about computer science, but about what I'm capable of.
+                            Onward to the next adventure!
+                        </p>
+                    </div>
+
+                </article>
+
+            </div> <!-- end entry -->
+
+            <div id="sidebar" class="s-content__sidebar large-4 column">
+
+                <div class="widget widget_tags">
+                    <h3 class="h6">Post Tags</h3>
+
+                    <div class="tagcloud group">
+                        <a href="#0">Life</a>
+                        <a href="#0">Graduation</a>
+                        <a href="#0">Brown</a>
+                        <a href="#0">Graduate School</a>
+                    </div>
+                </div>
+
+                <div class="widget widget_popular">
+                    <h3 class="h6">Other Posts</h3>
+                    <ul class="link-list">
+                        <li><a href="blog-1215-2021.html">Graduated from Vandy!!!</a></li>
+                    </ul>
+                </div>
+
+            </div> <!-- end sidebar -->
+
+        </div> <!-- end row -->
+
+    </div> <!-- end content-wrap -->
+
+
+    <!-- Footer
+    ================================================== -->
+    <footer class="s-footer">
+
+        <div class="row s-footer__bottom">
+            <div class="column">
+                <div class="ss-copyright">
+                    <span>© Ruida Zeng 2025</span>
+                    <span>Design by <a href="https://www.styleshout.com/">StyleShout</a></span>
+                </div>
+            </div>
+        </div>
+
+        <div class="ss-go-top">
+            <a class="smoothscroll" title="Back to Top" href="#top">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0l8 9h-6v15h-4v-15h-6z"/></svg>
+            </a>
+        </div>
+
+    </footer>
+
+
+    <!-- Java Script
+    ================================================== -->
+    <script src="../js/jquery-3.2.1.min.js"></script>
+    <script src="../js/main.js"></script>
+
+</body>
+
+</html>

--- a/blogs/blog-0710-2022.html
+++ b/blogs/blog-0710-2022.html
@@ -93,7 +93,7 @@
 
                     <div class="entry__content">
                         <p>
-                            I was born and raised in Guangzhou, China, which is the capital city of Guangdong province. Guangdong is the province where Cantonese is spoken, and Cantonese cuisine is one of the Eight Culinary Traditions of Chinese cuisine. Cantonese cuisine has a very long history, and it is known for its variety of ingredients, cooking methods, and flavors. In this blog post, I will introduce some of my favorite Cantonese dishes.
+                            I grew up eating Cantonese food, and it's honestly the cuisine I'm most nostalgic about. Cantonese cuisine comes from the Guangdong province of China and is one of the Eight Culinary Traditions of Chinese cuisine. It has a long history and is known for its variety of ingredients, cooking methods, and flavors. In this blog post, I want to share some of my all-time favorite Cantonese dishes.
                         </p>
 
                         <h3>Double-Skin Milk (双皮奶)</h3>
@@ -168,24 +168,6 @@
 
             <div id="sidebar" class="s-content__sidebar large-4 column">
 
-                <div class="widget widget--categories">
-                    <h3 class="h6">Categories</h3>
-                    <ul>
-                        <li><a href="#0" title="">Food</a> (1)</li>
-                    </ul>
-                </div>
-
-                <div class="widget widget_text group">
-                    <h3 class="h6">Introduction</h3>
-
-                    <p>
-                    Over the last few months in Guangzhou, China, I have had the opportunity to try some unique Cantonese food
-                    from all over the city. Some of them are well known dishes internationally, while some are rather exotic
-                    cuisine that are only popular locally. I will be introducing a few of them here in my blog from my personal
-                    tasting experience.
-                    </p>
-                </div>
-
                 <div class="widget widget_tags">
                     <h3 class="h6">Post Tags</h3>
 
@@ -199,10 +181,9 @@
                 </div>
 
                 <div class="widget widget_popular">
-                    <h3 class="h6">Popular Post</h3>
-
+                    <h3 class="h6">Other Posts</h3>
                     <ul class="link-list">
-                        <li><a href="blog-0710-2022.html">Cantonese Food Review (Part 1).</a></li>
+                        <li><a href="blog-0106-2023.html">New York City Trip Day 1 of 5</a></li>
                     </ul>
                 </div>
 

--- a/blogs/blog-1215-2021.html
+++ b/blogs/blog-1215-2021.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Graduated from Vandy!!!</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../images/icons/squirrel-icon.png" type="image/icon type">
+    <script src="../js/theme.js"></script>
+    <link rel="stylesheet" href="../css/base.css">
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../css/dark-mode.css">
+    <script src="../js/modernizr.js"></script>
+    <script defer src="../js/fontawesome/all.min.js"></script>
+    <script src="../js/sky.js" defer></script>
+</head>
+
+<body id="top">
+    <canvas class="sky-canvas" aria-hidden="true"></canvas>
+
+    <!-- preloader
+    ================================================== -->
+    <div id="preloader">
+        <div id="loader" class="dots-fade">
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+    </div>
+
+    <!-- Header
+    ================================================== -->
+    <header class="s-header">
+
+        <div class="row">
+            <div class="s-header__content column">
+                <div class="s-header__brand">
+                    <h1 class="s-header__logotext">
+                        <a href="../blogs.html" title="">Ruida's Room</a>
+                    </h1>
+                    <p class="s-header__tagline">Private thoughts, book & movie reviews, and yummy recipes.</p>
+                </div>
+            </div>
+        </div> <!-- end row -->
+
+        <nav class="s-header__nav-wrap">
+
+          <div class="row">
+
+               <ul class="s-header__nav">
+                   <li><a href="../index.html">Home</a></li>
+                   <li><a href="../news.html">News</a></li>
+                   <li><a href="../publications.html">Publications</a></li>
+                   <li><a href="../projects.html">Projects</a></li>
+                   <li class="current"><a href="../blogs.html">Blogs</a></li>
+                   <li><a href="../contact.html">Contact</a></li>
+               </ul>
+
+           </div>
+
+       </nav>
+
+        <a class="header-menu-toggle" href="#0"><span>Menu</span></a>
+
+    </header>
+
+    <!-- Content
+    ================================================== -->
+    <div class="s-content">
+
+        <div class="row">
+
+            <div id="main" class="s-content__main large-8 column">
+
+                <article class="entry">
+
+                    <header class="entry__header">
+
+                        <h2 class="entry__title h1">
+                            <a href="blog-1215-2021.html" title="Graduated from Vandy!!!">Graduated from Vandy!!!</a>
+                        </h2>
+
+                        <div class="entry__meta">
+                            <ul>
+                                <li>December 15, 2021</li>
+                                <li>Ruida Zeng</li>
+                            </ul>
+                        </div>
+
+                    </header>
+
+                    <div class="entry__content">
+                        <p>
+                            Today I took the last exam of my undergraduate college career. The campus was peaceful
+                            and quiet, as most people had already left for winter break. Although I expected the
+                            end to be more ceremonious than this, I couldn't help but think that the rare tranquility
+                            called for a moment of self-reflection.
+                        </p>
+                        <p>
+                            For me, college was a juxtaposition of accompolishments and failures, of hope and despair,
+                            of dreams and nightmares. Looking back, there were memories that I cherish dearly as well
+                            as things that I deeply regret. At the end of the day, the most important thing about 3.5
+                            years at Vanderbilt is that I grew tremendously as a person, both in terms of my technical
+                            knowledge and my mental maturity. And for that, I am content and forever grateful.
+                        </p>
+                        <div class="entry__content-media">
+                            <img src="../images/vandy.jpg"
+                                 srcset="../images/vandy.jpg 1000w,
+                                         ../images/vandy.jpg 500w"
+                                 sizes="(max-width: 500px) 100vw, 500px" alt="vandy">
+                        </div>
+                    </div>
+
+                </article>
+
+            </div> <!-- end entry -->
+
+            <div id="sidebar" class="s-content__sidebar large-4 column">
+
+                <div class="widget widget_tags">
+                    <h3 class="h6">Post Tags</h3>
+
+                    <div class="tagcloud group">
+                        <a href="#0">Life</a>
+                        <a href="#0">Graduation</a>
+                        <a href="#0">Vanderbilt</a>
+                        <a href="#0">College</a>
+                    </div>
+                </div>
+
+                <div class="widget widget_popular">
+                    <h3 class="h6">Other Posts</h3>
+                    <ul class="link-list">
+                        <li><a href="blog-0526-2024.html">Graduated from Brown!!!</a></li>
+                    </ul>
+                </div>
+
+            </div> <!-- end sidebar -->
+
+        </div> <!-- end row -->
+
+    </div> <!-- end content-wrap -->
+
+
+    <!-- Footer
+    ================================================== -->
+    <footer class="s-footer">
+
+        <div class="row s-footer__bottom">
+            <div class="column">
+                <div class="ss-copyright">
+                    <span>© Ruida Zeng 2025</span>
+                    <span>Design by <a href="https://www.styleshout.com/">StyleShout</a></span>
+                </div>
+            </div>
+        </div>
+
+        <div class="ss-go-top">
+            <a class="smoothscroll" title="Back to Top" href="#top">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0l8 9h-6v15h-4v-15h-6z"/></svg>
+            </a>
+        </div>
+
+    </footer>
+
+
+    <!-- Java Script
+    ================================================== -->
+    <script src="../js/jquery-3.2.1.min.js"></script>
+    <script src="../js/main.js"></script>
+
+</body>
+
+</html>

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -702,6 +702,31 @@ body.dark .btn-outline-primary:not(:disabled):not(.disabled):active {
     }
 }
 
+/* --- Links dark mode --- */
+[data-theme="dark"] .s-content__sidebar .link-list li a,
+[data-theme="dark"] .s-footer__list li a,
+[data-theme="dark"] .s-footer__social li a,
+[data-theme="dark"] .entry__post-nav li a {
+    color: #8bb8d9;
+}
+[data-theme="dark"] .s-content__sidebar .link-list li a:hover,
+[data-theme="dark"] .s-content__sidebar .link-list li a:focus,
+[data-theme="dark"] .s-footer__list li a:hover,
+[data-theme="dark"] .s-footer__list li a:focus,
+[data-theme="dark"] .s-footer__social li a:hover,
+[data-theme="dark"] .s-footer__social li a:focus,
+[data-theme="dark"] .entry__post-nav li a:hover,
+[data-theme="dark"] .entry__post-nav li a:focus {
+    color: #ffffff;
+}
+[data-theme="dark"] .entry h2 a {
+    color: #8bb8d9;
+}
+[data-theme="dark"] .entry h2 a:hover,
+[data-theme="dark"] .entry h2 a:focus {
+    color: #ffffff;
+}
+
 /* --- Comment section dark mode --- */
 [data-theme="dark"] .comment__info .comment__author {
     color: #ffffff;

--- a/css/main.css
+++ b/css/main.css
@@ -1933,7 +1933,7 @@ button::-moz-focus-inner, input::-moz-focus-inner {
 }
 
 .s-content__sidebar .link-list li a {
-    color: #3e3e3e;
+    color: #2a6496;
 }
 
 .s-content__sidebar .link-list li a:hover, .s-content__sidebar .link-list li a:focus {
@@ -2061,7 +2061,7 @@ button::-moz-focus-inner, input::-moz-focus-inner {
 }
 
 .s-footer__list li a {
-    color: #3e3e3e;
+    color: #2a6496;
 }
 
 .s-footer__list li a:hover, .s-footer__list li a:focus {
@@ -2090,7 +2090,7 @@ button::-moz-focus-inner, input::-moz-focus-inner {
 }
 
 .s-footer__social li a {
-    color: #3e3e3e;
+    color: #2a6496;
 }
 
 .s-footer__social li a:hover, .s-footer__social li a:focus {
@@ -2284,11 +2284,11 @@ button::-moz-focus-inner, input::-moz-focus-inner {
 }
 
 .entry h2 a {
-    color: #272727;
+    color: #1a5276;
 }
 
 .entry h2 a:hover, .entry h2 a:focus {
-    color: #000000;
+    color: #2a6496;
 }
 
 .entry__header {
@@ -2371,7 +2371,7 @@ button::-moz-focus-inner, input::-moz-focus-inner {
 }
 
 .entry__post-nav li a {
-    color: #3e3e3e;
+    color: #2a6496;
 }
 
 .entry__post-nav li strong {


### PR DESCRIPTION
## Summary
- **New blog post**: Added "Graduated from Brown!!!" (May 26, 2024)
- **Standalone blog pages**: Moved all inline content (Vandy graduation, NYC trip vlogs, food review) into individual pages under `blogs/`. The blog listing page (`blogs.html`) now shows only title, date, and author for a clean index.
- **Sidebar cleanup**: Removed unused Categories and Introduction widgets from blog sidebars. Kept Post Tags (decorative) and replaced auto-generated "Other Posts" with curated cross-links (e.g., Brown ↔ Vandy, NYC vlogs link to each other, food review → NYC Day 1).
- **Link visibility**: Fixed link colors sitewide so they are visually distinct from body text in both light mode (`#2a6496` blue) and dark mode (`#8bb8d9` soft blue), covering sidebar links, footer links, blog titles, and post navigation.
- **Privacy**: Replaced personal location info in the Cantonese food review intro with a more general opening.